### PR TITLE
Fix midi channel zero

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -134,7 +134,7 @@ class MainWindow(QMainWindow):
 
         self.midi_channel_label = QLabel("Channel:")
         self.midi_channel_combobox = QComboBox()
-        self.midi_channel_combobox.addItems(map(str, range(17)))
+        self.midi_channel_combobox.addItems(map(str, range(1, 17)))
         self.midi_channel_combobox.setCurrentText(
             str(self.profile_data.get("channel", 0))
         )
@@ -302,7 +302,7 @@ class MainWindow(QMainWindow):
     def new_profile(self):
         template_json = {
             "name": "Template",
-            "channel": 0,
+            "channel": 1,
             "buttons": [
                 {"order": 0, "color": "green", "program_change": 1, "name": "button 1"}
             ],

--- a/profiles/brunetti-059-red.json
+++ b/profiles/brunetti-059-red.json
@@ -1,6 +1,6 @@
 {
     "name": "Brunetti 059",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/brunetti-xl2-revo.json
+++ b/profiles/brunetti-xl2-revo.json
@@ -1,6 +1,6 @@
 {
     "name": "Brunetti XL\" R-EVO",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/hughes-and-kettner-trilogy.json
+++ b/profiles/hughes-and-kettner-trilogy.json
@@ -1,6 +1,6 @@
 {
     "name": "HUGHES AND KETTNER TRILOGY",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/marshall-jvm410hjs.json
+++ b/profiles/marshall-jvm410hjs.json
@@ -1,6 +1,6 @@
 {
     "name": "Marshall JVM410HJS",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/mesa-boogie-mark_vii.json
+++ b/profiles/mesa-boogie-mark_vii.json
@@ -1,6 +1,6 @@
 {
     "name": "MESA BOOGIE MARK VII",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/midi-channel-switcher-8.json
+++ b/profiles/midi-channel-switcher-8.json
@@ -1,6 +1,6 @@
 {
     "name": "MIDI Channel Switcher 8",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/n-audio-4X4.json
+++ b/profiles/n-audio-4X4.json
@@ -1,6 +1,6 @@
 {
     "name": "N-AUDIO 4X4",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/n-audio-4X4_color.json
+++ b/profiles/n-audio-4X4_color.json
@@ -1,6 +1,6 @@
 {
     "name": "N-AUDIO 4X4",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/n-audio-8X7.json
+++ b/profiles/n-audio-8X7.json
@@ -1,6 +1,6 @@
 {
     "name": "N-AUDIO 8X7",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/n-audio-8X7_color.json
+++ b/profiles/n-audio-8X7_color.json
@@ -1,6 +1,6 @@
 {
     "name": "N-AUDIO 8X7",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,

--- a/profiles/sample.json
+++ b/profiles/sample.json
@@ -1,6 +1,6 @@
 {
     "name": "Sample",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 1,

--- a/profiles/synergy-syn-50.json
+++ b/profiles/synergy-syn-50.json
@@ -1,6 +1,6 @@
 {
     "name": "SYNERGY SYN 50",
-    "channel": 0,
+    "channel": 1,
     "buttons": [
         {
             "order": 0,


### PR DESCRIPTION
# Pull Request

## Description
Fix the bug of the MIDI channel dropdown presents a list starting from 0 to 16, instead of 1-16.

## Changes Made
* fix: midi channel number
* fix: update channel profiles


## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

## Related Issues
<!-- Mention any related issues using the GitHub issue syntax (e.g., #123). -->

## Additional Information
<!-- Add any additional information that might be helpful for the reviewer. -->
