### PR TITLE
feat: add new feature to remember size and position of the main window

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleShortVersionString</key>
-    <string>1.2.3</string>
+    <string>1.3.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
 </dict>

--- a/Info.plist
+++ b/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleShortVersionString</key>
-    <string>1.2.2</string>
+    <string>1.2.3</string>
     <key>CFBundleVersion</key>
     <string>1</string>
 </dict>

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -44,6 +44,7 @@ class MainWindow(QMainWindow):
 
         self.script_directory = script_directory
         plist_path = os.path.join(script_directory, "Info.plist")
+        self.setting_file_path = os.path.join(self.script_directory, "settings.json")
 
         # Load version from Info.plist
         with open(plist_path, "rb") as plist_file:
@@ -89,7 +90,8 @@ class MainWindow(QMainWindow):
 
     def setup_ui(self):
         self.setWindowTitle(self.profile_data["name"])
-        self.setGeometry(100, 100, 600, 400)
+        # self.setGeometry(100, 100, 600, 400)
+        self.load_window_position()
 
         self.setup_menu_bar()
         self.setup_midi_layout()
@@ -97,6 +99,10 @@ class MainWindow(QMainWindow):
 
         self.set_status_bar()
         self.set_window_icon()
+
+    def closeEvent(self, event):
+        self.save_window_position()
+        super().closeEvent(event)
 
     def setup_menu_bar(self):
         menubar = self.menuBar()
@@ -190,6 +196,30 @@ class MainWindow(QMainWindow):
             )
         )
         return button
+
+    def save_window_position(self):
+        new_position = {
+            "x": self.x(),
+            "y": self.y(),
+            "width": self.width(),
+            "height": self.height(),
+        }
+
+        with open(self.setting_file_path, "r") as file:
+            settings = json.load(file)
+        settings.update(new_position)
+        with open(self.setting_file_path, "w") as file:
+            json.dump(settings, file, indent=4)
+
+    def load_window_position(self):
+        try:
+            with open(self.setting_file_path, "r") as file:
+                position = json.load(file)
+                self.setGeometry(
+                    position["x"], position["y"], position["width"], position["height"]
+                )
+        except FileNotFoundError:
+            self.setGeometry(100, 100, 600, 400)
 
     def save_channel(self):
         try:

--- a/settings.json
+++ b/settings.json
@@ -4,5 +4,9 @@
     "icon": "icon.ico",
     "font": "Arial",
     "size": 14,
-    "buttons_per_row": 3
+    "buttons_per_row": 3,
+    "x": 100,
+    "y": 72,
+    "width": 600,
+    "height": 400
 }


### PR DESCRIPTION
# Pull Request

## Description
Fixing the MIDI channel bug and adding a new feature of remembering the previous size and position of the app.

## Changes made
* profiles updated
* midi channel dropdown updated
* main windows size and position is stored under settings

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation accordingly.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

## Related Issues
<!-- Mention any related issues using the GitHub issue syntax (e.g., #123). -->

## Additional Information
<!-- Add any additional information that might be helpful for the reviewer. -->
